### PR TITLE
Ignore data with large time gaps

### DIFF
--- a/.styleguide
+++ b/.styleguide
@@ -25,6 +25,7 @@ includeOtherLibs {
   ^Eigen
   ^frc
   ^imgui
+  ^implot\.h$
   ^ntcore
   ^portable-file-dialogs
   ^units

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,10 @@ model {
         include "**/*.cpp"
       }
       binaries.all {
+        // Only build/run release version of tests
+        if (it.buildType.name.contains('debug')) {
+          it.buildable = false
+        }
         nativeUtils.useRequiredLibrary(it, "googletest_static")
         it.cppCompiler.define("RUNNING_SYSID_TESTS")
       }

--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,7 @@ model {
       }
     }
     $.testSuites.sysidIntegrationTest.binaries.each { bin ->
-      if (bin.buildable && bin.name.contains("debug")) {
+      if (bin.buildable && bin.name.contains("release")) {
         Task run = project.tasks.create("runIntegrationTests", Exec) {
           commandLine bin.tasks.install.runScriptFile.get().asFile.toString()
         }

--- a/integration_test_project/build.gradle
+++ b/integration_test_project/build.gradle
@@ -47,8 +47,8 @@ def includeDesktopSupport = true
 // upon debugging
 dependencies {
   if (System.getenv()['CI'] == null) {
-      simulation wpi.deps.sim.gui(wpi.platforms.desktop, true)
-      simulation wpi.deps.sim.driverstation(wpi.platforms.desktop, true)
+      simulation wpi.deps.sim.gui(wpi.platforms.desktop, false)
+      simulation wpi.deps.sim.driverstation(wpi.platforms.desktop, false)
   }
     // Websocket extensions require additional configuration.
     // simulation wpi.deps.sim.ws_server(wpi.platforms.desktop, true)
@@ -96,5 +96,5 @@ model {
 }
 
 task simulateCpp {
-    dependsOn 'simulateFrcUserProgram' + wpi.platforms.desktop.capitalize() + 'DebugExecutable'
+    dependsOn 'simulateFrcUserProgram' + wpi.platforms.desktop.capitalize() + 'ReleaseExecutable'
 }

--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -483,13 +483,13 @@ AnalysisManager::Gains AnalysisManager::Calculate() {
     fb = sysid::CalculatePositionFeedbackGains(
         m_settings.preset, m_settings.lqr, gains,
         m_settings.convertGainsToEncTicks
-            ? m_settings.gearing * m_settings.epr * m_factor
+            ? m_settings.gearing * m_settings.cpr * m_factor
             : 1);
   } else {
     fb = sysid::CalculateVelocityFeedbackGains(
         m_settings.preset, m_settings.lqr, gains,
         m_settings.convertGainsToEncTicks
-            ? m_settings.gearing * m_settings.epr * m_factor
+            ? m_settings.gearing * m_settings.cpr * m_factor
             : 1);
   }
   return {ff, fb, m_trackWidth};

--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -120,7 +120,7 @@ void TrimStepVoltageData(std::vector<PreparedData>* data) {
 
   for (size_t i = 0; i < data->size(); ++i) {
     // Get the current acceleration.
-    double acc = data->at(i).acceleration;
+    double acc = std::abs(data->at(i).acceleration);
 
     // If we are not in caution, the acceleration values are still increasing.
     if (!caution) {
@@ -146,6 +146,8 @@ void TrimStepVoltageData(std::vector<PreparedData>* data) {
       break;
     }
   }
+
+  data->erase(data->begin(), data->begin() + idx);
 }
 
 /**

--- a/src/main/native/cpp/analysis/ArmSim.cpp
+++ b/src/main/native/cpp/analysis/ArmSim.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "sysid/analysis/ArmSim.h"
+
+#include <cmath>
+
+#include <frc/StateSpaceUtil.h>
+#include <frc/system/NumericalIntegration.h>
+#include <wpi/MathExtras.h>
+
+using namespace sysid;
+
+ArmSim::ArmSim(double Ks, double Kv, double Ka, double Kcos,
+               double initialPosition, double initialVelocity) {
+  // u = Ks sgn(x) + Kv x + Ka a + Kcos cos(theta)
+  // Ka a = u - Ks sgn(x) - Kv x - Kcos cos(theta)
+  // a = 1/Ka u - Ks/Ka sgn(x) - Kv/Ka x - Kcos/Ka cos(theta)
+  // a = -Kv/Ka x + 1/Ka u - Ks/Ka sgn(x) - Kcos/Ka cos(theta)
+  // a = Ax + Bu + c sgn(x) + d cos(theta)
+  Reset(initialPosition, initialVelocity);
+  m_A << -Kv / Ka;
+  m_B << 1.0 / Ka;
+  m_c << -Ks / Ka;
+  m_d << -Kcos / Ka;
+}
+
+void ArmSim::Update(units::volt_t voltage, units::second_t dt) {
+  // Returns arm acceleration under gravity
+  auto f =
+      [=](const Eigen::Matrix<double, 2, 1>& x,
+          const Eigen::Matrix<double, 1, 1>& u) -> Eigen::Matrix<double, 2, 1> {
+    return frc::MakeMatrix<2, 1>(
+        x(1), (m_A * x.block<1, 1>(1, 0) + m_B * u + m_c * wpi::sgn(x(1)) +
+               m_d * std::cos(x(0)))(0));
+  };
+
+  m_x = frc::RKF45(f, m_x, frc::MakeMatrix<1, 1>(voltage.to<double>()), dt);
+}
+
+double ArmSim::GetPosition() const {
+  return m_x(0);
+}
+
+double ArmSim::GetVelocity() const {
+  return m_x(1);
+}
+
+double ArmSim::GetAcceleration(units::volt_t voltage) const {
+  auto u = frc::MakeMatrix<1, 1>(voltage.to<double>());
+  return (m_A * m_x.block<1, 1>(1, 0) + m_B * u +
+          m_c * wpi::sgn(GetVelocity()) + m_d * std::cos(m_x(0)))(0);
+}
+
+void ArmSim::Reset(double position, double velocity) {
+  m_x << position, velocity;
+}

--- a/src/main/native/cpp/analysis/ElevatorSim.cpp
+++ b/src/main/native/cpp/analysis/ElevatorSim.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "sysid/analysis/ElevatorSim.h"
+
+#include <frc/StateSpaceUtil.h>
+#include <frc/system/Discretization.h>
+#include <wpi/MathExtras.h>
+
+using namespace sysid;
+
+ElevatorSim::ElevatorSim(double Ks, double Kv, double Ka, double Kg,
+                         double initialPosition, double initialVelocity) {
+  // dx/dt = Ax + Bu + c sgn(x) + d
+  Reset(initialPosition, initialVelocity);
+  m_A << 0.0, 1.0, 0.0, -Kv / Ka;
+  m_B << 0.0, 1.0 / Ka;
+  m_c << 0.0, -Ks / Ka;
+  m_d << 0.0, -Kg / Ka;
+}
+
+void ElevatorSim::Update(units::volt_t voltage, units::second_t dt) {
+  auto u = frc::MakeMatrix<1, 1>(voltage.to<double>());
+
+  // Given dx/dt = Ax + Bu + c sgn(x) + d,
+  // x_k+1 = e^(AT) x_k + A^-1 (e^(AT) - 1) (Bu + c sgn(x) + d)
+  Eigen::Matrix<double, 2, 2> Ad;
+  Eigen::Matrix<double, 2, 1> Bd;
+  frc::DiscretizeAB<2, 1>(m_A, m_B, dt, &Ad, &Bd);
+  m_x = Ad * m_x + Bd * u +
+        Bd * m_B.householderQr().solve(m_c * wpi::sgn(GetVelocity()) + m_d);
+}
+
+double ElevatorSim::GetPosition() const {
+  return m_x(0);
+}
+
+double ElevatorSim::GetVelocity() const {
+  return m_x(1);
+}
+
+double ElevatorSim::GetAcceleration(units::volt_t voltage) const {
+  auto u = frc::MakeMatrix<1, 1>(voltage.to<double>());
+  return (m_A * m_x + m_B * u + m_c * wpi::sgn(GetVelocity()) + m_d)(1);
+}
+
+void ElevatorSim::Reset(double position, double velocity) {
+  m_x << position, velocity;
+}

--- a/src/main/native/cpp/analysis/FeedforwardAnalysis.cpp
+++ b/src/main/native/cpp/analysis/FeedforwardAnalysis.cpp
@@ -4,10 +4,95 @@
 
 #include "sysid/analysis/FeedforwardAnalysis.h"
 
+#include <cmath>
+#include <numeric>
+
 #include "sysid/analysis/AnalysisManager.h"
 #include "sysid/analysis/OLS.h"
 
 using namespace sysid;
+
+/**
+ * Populates OLS vector for u = Ks + Kv v + Ka a.
+ *
+ * @param d        List of characterization data.
+ * @param type     Type of system being identified.
+ * @param olsData  Vector of OLS data.
+ */
+static void PopulateAccelOLSVector(const std::vector<PreparedData>& d,
+                                   const AnalysisType& type,
+                                   std::vector<double>& olsData) {
+  for (auto&& pt : d) {
+    // Add the dependent variable (voltage)
+    olsData.push_back(pt.voltage);
+
+    // Add the intercept term (for Ks)
+    olsData.push_back(std::copysign(1, pt.velocity));
+
+    // Add the velocity term (for Kv)
+    olsData.push_back(pt.velocity);
+
+    // Add the acceleration term (for Ka)
+    olsData.push_back(pt.acceleration);
+
+    if (type == analysis::kArm) {
+      // Add the cosine term (for Kcos)
+      olsData.push_back(pt.cos);
+    }
+  }
+}
+
+/**
+ * Populates OLS vector for x_k+1 = alpha x_k + beta u_k + gamma sgn(x_k).
+ *
+ * @param d        List of characterization data.
+ * @param type     Type of system being identified.
+ * @param olsData  Vector of OLS data.
+ * @param dts      List of periods.
+ */
+static void PopulateNextVelOLSVector(const std::vector<PreparedData>& d,
+                                     const AnalysisType& type,
+                                     std::vector<double>& olsData,
+                                     std::vector<double>& dts) {
+  auto PushData = [&](int i) {
+    // x_k+1 = alpha x_k + beta u_k + gamma sgn(x_k)
+
+    // Add the dependent variable (next velocity)
+    olsData.push_back(d[i + 1].velocity);
+
+    // Add the velocity term (for alpha)
+    olsData.push_back(d[i].velocity);
+
+    // Add the voltage term (for beta)
+    olsData.push_back(d[i].voltage);
+
+    // Add the intercept term (for gamma)
+    olsData.push_back(std::copysign(1, d[i].velocity));
+
+    // Add test-specific variables
+    if (type == analysis::kElevator) {
+      // Add the gravity term (for Kg)
+      olsData.push_back(1.0);
+    }
+  };
+
+  for (size_t i = 0; i < d.size() - 1; ++i) {
+    double dt = d[i + 1].timestamp - d[i].timestamp;
+    if (dts.size() == 0) {
+      dts.emplace_back(dt);
+      PushData(i);
+    } else {
+      double dtMean = std::accumulate(dts.begin(), dts.end(), 0.0) / dts.size();
+
+      // Don't include velocity data with a large time gap in it. This usually
+      // occurs between test runs.
+      if (std::abs(dt - dtMean) < dtMean / 2.0) {
+        dts.emplace_back(dt);
+        PushData(i);
+      }
+    }
+  }
+}
 
 std::tuple<std::vector<double>, double> sysid::CalculateFeedforwardGains(
     const Storage& data, const AnalysisType& type) {
@@ -17,32 +102,35 @@ std::tuple<std::vector<double>, double> sysid::CalculateFeedforwardGains(
                   (std::get<0>(data).size() + std::get<1>(data).size()));
 
   // Iterate through the data and add it to our raw vector.
-  auto PopulateVector = [&](const std::vector<PreparedData>& d) {
-    for (auto&& pt : d) {
-      // Add the dependent variable (voltage).
-      olsData.push_back(pt.voltage);
+  if (type == analysis::kArm) {
+    PopulateAccelOLSVector(std::get<0>(data), type, olsData);
+    PopulateAccelOLSVector(std::get<1>(data), type, olsData);
 
-      // Add the intercept term (for Ks).
-      olsData.push_back(std::copysign(1, pt.velocity));
+    // Gains are Ks, Kv, Ka, Kcos
+    return sysid::OLS(olsData, type.independentVariables);
+  } else {
+    // This implements the OLS algorithm defined in
+    // https://file.tavsys.net/control/sysid-ols.pdf.
 
-      // Add the velocity term (for Kv).
-      olsData.push_back(pt.velocity);
+    std::vector<double> dts;
+    PopulateNextVelOLSVector(std::get<0>(data), type, olsData, dts);
+    PopulateNextVelOLSVector(std::get<1>(data), type, olsData, dts);
+    double dt = std::accumulate(dts.begin(), dts.end(), 0.0) / dts.size();
 
-      // Add the acceleration term (for Ka).
-      olsData.push_back(pt.acceleration);
+    auto ols = sysid::OLS(olsData, type.independentVariables);
+    double alpha = std::get<0>(ols)[0];
+    double beta = std::get<0>(ols)[1];
+    double gamma = std::get<0>(ols)[2];
 
-      // Add test-specific variables.
-      if (wpi::StringRef(type.name) == "Elevator") {
-        // Add the gravity term (for Kg)
-        olsData.push_back(1.0);
-      } else if (wpi::StringRef(type.name) == "Arm") {
-        // Add the cosine term (for Kcos)
-        olsData.push_back(pt.cos);
-      }
+    std::vector<double> gains{{-gamma / beta, (1 - alpha) / beta,
+                               dt * (alpha - 1) / (beta * std::log(alpha))}};
+
+    if (type == analysis::kElevator) {
+      double delta = std::get<0>(ols)[3];
+      gains.emplace_back(-delta / beta);
     }
-  };
-  PopulateVector(std::get<0>(data));
-  PopulateVector(std::get<1>(data));
 
-  return sysid::OLS(olsData, type.independentVariables);
+    // Gains are Ks, Kv, Ka, Kg (elevator only)
+    return std::tuple{gains, std::get<1>(ols)};
+  }
 }

--- a/src/main/native/cpp/analysis/SimpleMotorSim.cpp
+++ b/src/main/native/cpp/analysis/SimpleMotorSim.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "sysid/analysis/SimpleMotorSim.h"
+
+#include <frc/StateSpaceUtil.h>
+#include <frc/system/Discretization.h>
+#include <wpi/MathExtras.h>
+
+using namespace sysid;
+
+SimpleMotorSim::SimpleMotorSim(double Ks, double Kv, double Ka,
+                               double initialPosition, double initialVelocity) {
+  // dx/dt = Ax + Bu + c sgn(x)
+  Reset(initialPosition, initialVelocity);
+  m_A << 0.0, 1.0, 0.0, -Kv / Ka;
+  m_B << 0.0, 1.0 / Ka;
+  m_c << 0.0, -Ks / Ka;
+}
+
+void SimpleMotorSim::Update(units::volt_t voltage, units::second_t dt) {
+  auto u = frc::MakeMatrix<1, 1>(voltage.to<double>());
+
+  // Given dx/dt = Ax + Bu + c sgn(x),
+  // x_k+1 = e^(AT) x_k + A^-1 (e^(AT) - 1) (Bu + c sgn(x))
+  Eigen::Matrix<double, 2, 2> Ad;
+  Eigen::Matrix<double, 2, 1> Bd;
+  frc::DiscretizeAB<2, 1>(m_A, m_B, dt, &Ad, &Bd);
+  m_x = Ad * m_x + Bd * u +
+        Bd * m_B.householderQr().solve(m_c * wpi::sgn(GetVelocity()));
+}
+
+double SimpleMotorSim::GetPosition() const {
+  return m_x(0);
+}
+
+double SimpleMotorSim::GetVelocity() const {
+  return m_x(1);
+}
+
+double SimpleMotorSim::GetAcceleration(units::volt_t voltage) const {
+  auto u = frc::MakeMatrix<1, 1>(voltage.to<double>());
+  return (m_A * m_x + m_B * u + m_c * wpi::sgn(GetVelocity()))(1);
+}
+
+void SimpleMotorSim::Reset(double position, double velocity) {
+  m_x << position, velocity;
+}

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -234,13 +234,23 @@ void Analyzer::Display() {
                          isRotational ? ImGuiInputTextFlags_ReadOnly
                                       : ImGuiInputTextFlags_None);
 
+      bool ex = false;
+
       if (ImGui::Button("Close")) {
         ImGui::CloseCurrentPopup();
-        m_manager->OverrideUnits(m_unit, m_factor);
-        Calculate();
+        try {
+          m_manager->OverrideUnits(m_unit, m_factor);
+          Calculate();
+        } catch (const std::exception& e) {
+          ex = true;
+          m_exception = e.what();
+        }
       }
 
       ImGui::EndPopup();
+      if (ex) {
+        ImGui::OpenPopup("Exception Caught!");
+      }
     }
 
     ImGui::SameLine();

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -4,8 +4,6 @@
 
 #include "sysid/view/Analyzer.h"
 
-#include <implot.h>
-
 #include <algorithm>
 #include <exception>
 
@@ -20,6 +18,9 @@
 
 #include "sysid/Util.h"
 #include "sysid/analysis/AnalysisType.h"
+#include "sysid/analysis/ArmSim.h"
+#include "sysid/analysis/ElevatorSim.h"
+#include "sysid/analysis/SimpleMotorSim.h"
 
 using namespace sysid;
 
@@ -429,65 +430,16 @@ void Analyzer::Display() {
 
             // Plot time domain simulation of feedforward gains
             if (i == 2) {
-              ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 1.5);
-
-              double Ks = m_ff[0];
-              double Kv = m_ff[1];
-              double Ka = m_ff[2];
-
-              // Create a continuous state-space model from feedforward gains
-              //
-              // Feedforward model is
-              //
-              // u = Ks + Kv v + Ka a
-              //
-              // Solve for a.
-              //
-              // Ka a = -Kv v + u - Ks
-              // a = -Kv/Ka v + 1/Ka u - Ks/Ka
-              //
-              // dx/dt = Ax + Bu + c, so by inspection:
-              double A = -Kv / Ka;
-              double B = 1.0 / Ka;
-              double c = -Ks / Ka;
-
-              std::vector<double> xs;
-              std::vector<double> ys;
-
-              // Get data list and initialize model state
-              auto preparedData = *(data.data());
-              xs.emplace_back(0.0);
-              ys.emplace_back(preparedData[0].velocity);
-
-              double x = preparedData[0].velocity;
-              double t = 0.0;
-              for (int j = 1; j < preparedData.size(); ++j) {
-                const auto& prev = preparedData[j - 1];
-                const auto& now = preparedData[j];
-
-                double dt = now.timestamp - prev.timestamp;
-                t += dt;
-
-                // If there's a large gap or the time went backwards, it's a new
-                // section of data, so reset the model state
-                if (dt < 0.0 || dt > 1.0) {
-                  ImPlot::PlotLine("##Fit", &xs[0], &ys[0], xs.size());
-                  xs.clear();
-                  ys.clear();
-                  x = now.velocity;
-                  continue;
-                }
-
-                // Given dx/dt = Ax + Bu + c,
-                // x_k+1 = e^(AT) x_k + A^-1 (e^(AT) - 1) (Bu + c)
-                double Ad = std::exp(A * dt);
-                double Bd = 1.0 / A * (Ad - 1) * B;
-                x = Ad * x + Bd * prev.voltage +
-                    1.0 / A * (Ad - 1) * c * wpi::sgn(x);
-                xs.emplace_back(t);
-                ys.emplace_back(x);
+              if (m_type == analysis::kElevator) {
+                PlotTimeDomainSim(data, sysid::ElevatorSim{m_ff[0], m_ff[1],
+                                                           m_ff[2], m_ff[3]});
+              } else if (m_type == analysis::kArm) {
+                PlotTimeDomainSim(
+                    data, sysid::ArmSim{m_ff[0], m_ff[1], m_ff[2], m_ff[3]});
+              } else {
+                PlotTimeDomainSim(
+                    data, sysid::SimpleMotorSim{m_ff[0], m_ff[1], m_ff[2]});
               }
-              ImPlot::PlotLine("##Fit", &xs[0], &ys[0], xs.size());
             }
 
             ImPlot::EndPlot();

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -263,8 +263,8 @@ void Analyzer::Display() {
 
   // Function that displays a read-only value.
   auto ShowGain = [](const char* text, double* data) {
-    ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
-    ImGui::InputDouble(text, data, 0.0, 0.0, "%.3G",
+    ImGui::SetNextItemWidth(ImGui::GetFontSize() * 5);
+    ImGui::InputDouble(text, data, 0.0, 0.0, "%.5G",
                        ImGuiInputTextFlags_ReadOnly);
   };
 
@@ -406,6 +406,8 @@ void Analyzer::Display() {
 
       // Show time domain diagnostic plots.
       if (ImGui::BeginPopupModal("Time-Domain Diagnostics")) {
+        int i = 0;
+
         // Loop through the plot data sources that we have.
         for (auto&& data : m_timeDomainData) {
           // Make sure that the axes are properly scaled to show all data and
@@ -422,9 +424,76 @@ void Analyzer::Display() {
             // plot it directly.
             ImPlot::PlotScatterG("", data.getter, data.data(),
                                  data.data()->size() / factor);
+
+            // Plot time domain simulation of feedforward gains
+            if (i == 2) {
+              ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 1.5);
+
+              double Ks = m_ff[0];
+              double Kv = m_ff[1];
+              double Ka = m_ff[2];
+
+              // Create a continuous state-space model from feedforward gains
+              //
+              // Feedforward model is
+              //
+              // u = Ks + Kv v + Ka a
+              //
+              // Solve for a.
+              //
+              // Ka a = -Kv v + u - Ks
+              // a = -Kv/Ka v + 1/Ka u - Ks/Ka
+              //
+              // dx/dt = Ax + Bu + c, so by inspection:
+              double A = -Kv / Ka;
+              double B = 1.0 / Ka;
+              double c = -Ks / Ka;
+
+              std::vector<double> xs;
+              std::vector<double> ys;
+
+              // Get data list and initialize model state
+              auto preparedData = *(data.data());
+              xs.emplace_back(0.0);
+              ys.emplace_back(preparedData[0].velocity);
+
+              double x = preparedData[0].velocity;
+              double t = 0.0;
+              for (int j = 1; j < preparedData.size(); ++j) {
+                const auto& prev = preparedData[j - 1];
+                const auto& now = preparedData[j];
+
+                double dt = now.timestamp - prev.timestamp;
+                t += dt;
+
+                // If there's a large gap or the time went backwards, it's a new
+                // section of data, so reset the model state
+                if (dt < 0.0 || dt > 1.0) {
+                  ImPlot::PlotLine("##Fit", &xs[0], &ys[0], xs.size());
+                  xs.clear();
+                  ys.clear();
+                  x = now.velocity;
+                  continue;
+                }
+
+                // Given dx/dt = Ax + Bu + c,
+                // x_k+1 = e^(AT) x_k + A^-1 (e^(AT) - 1) (Bu + c)
+                double Ad = std::exp(A * dt);
+                double Bd = 1.0 / A * (Ad - 1) * B;
+                x = Ad * x + Bd * prev.voltage +
+                    1.0 / A * (Ad - 1) * c * wpi::sgn(x);
+                xs.emplace_back(t);
+                ys.emplace_back(x);
+              }
+              ImPlot::PlotLine("##Fit", &xs[0], &ys[0], xs.size());
+            }
+
             ImPlot::EndPlot();
           }
+
+          ++i;
         }
+
         // Button to close popup.
         if (ImGui::Button("Close")) {
           ImGui::CloseCurrentPopup();

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -507,19 +507,19 @@ void Analyzer::Display() {
 
       ImGui::SetCursorPosY(endY);
 
-      // Add EPR and Gearing for converting Feedback Gains
+      // Add CPR and Gearing for converting Feedback Gains
       ImGui::Separator();
       ImGui::Spacing();
 
-      if (ImGui::Checkbox("Convert Gains to Encoder Ticks",
+      if (ImGui::Checkbox("Convert Gains to Encoder Counts",
                           &m_settings.convertGainsToEncTicks)) {
         Calculate();
       }
       sysid::CreateTooltip(
-          "Whether the feedback gains should be in terms of encoder ticks or "
+          "Whether the feedback gains should be in terms of encoder counts or "
           "output units. Because smart motor controllers usually don't have "
           "direct access to the output units (i.e. m/s for a drivetrain), they "
-          "perform feedback on the encoder units directly. If you are using a "
+          "perform feedback on the encoder counts directly. If you are using a "
           "PID Controller on the RoboRIO, you are probably performing feedback "
           "on the output units directly.\n\nNote that if you have properly set "
           "up position and velocity conversion factors with the SPARK MAX, you "
@@ -538,12 +538,12 @@ void Analyzer::Display() {
             "encoder turns / # of output shaft turns).");
 
         ImGui::SetNextItemWidth(ImGui::GetFontSize() * 5);
-        if (ImGui::InputInt("EPR", &m_settings.epr, 0) && m_settings.epr > 0) {
+        if (ImGui::InputInt("CPR", &m_settings.cpr, 0) && m_settings.cpr > 0) {
           Calculate();
         }
         sysid::CreateTooltip(
-            "The edges per rotation of your encoder. This is the number of "
-            "ticks reported in user code when the encoder is rotated exactly "
+            "The counts per rotation of your encoder. This is the number of "
+            "counts reported in user code when the encoder is rotated exactly "
             "once. Some common values for various motors/encoders "
             "are:\n\nFalcon "
             "500: 2048\nNEO: 1\nCTRE Mag Encoder / CANCoder: 4096\nREV Through "

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -173,7 +173,9 @@ void Analyzer::Display() {
 
   // Show the file location along with an option to choose.
   if (ImGui::Button("Select")) {
-    m_selector = std::make_unique<pfd::open_file>("Select Data");
+    m_selector = std::make_unique<pfd::open_file>(
+        "Select Data", "",
+        std::vector<std::string>{"JSON File", SYSID_PFD_JSON_EXT});
   }
   ImGui::SameLine();
   ImGui::SetNextItemWidth(width - ImGui::CalcTextSize("Select").x);

--- a/src/main/native/cpp/view/JSONConverter.cpp
+++ b/src/main/native/cpp/view/JSONConverter.cpp
@@ -11,12 +11,15 @@
 #include <portable-file-dialogs.h>
 #include <wpi/timestamp.h>
 
+#include "sysid/Util.h"
+
 using namespace sysid;
 
 void JSONConverter::Display() {
   if (ImGui::Button("Select frc-characterization JSON")) {
-    m_opener =
-        std::make_unique<pfd::open_file>("Select frc-characterization JSON");
+    m_opener = std::make_unique<pfd::open_file>(
+        "Select frc-characterization JSON", "",
+        std::vector<std::string>{"JSON File", SYSID_PFD_JSON_EXT});
   }
 
   if (m_opener && m_opener->ready()) {

--- a/src/main/native/cpp/view/Logger.cpp
+++ b/src/main/native/cpp/view/Logger.cpp
@@ -34,8 +34,7 @@ Logger::Logger(wpi::Logger& logger) : m_logger(logger) {
     }
   });
 
-  // Initialize team number from storage.
-  m_team = glass::GetStorage().GetIntRef("Team");
+  m_ntSettings.EnableServerOption(false);
 }
 
 void Logger::Display() {

--- a/src/main/native/cpp/view/Logger.cpp
+++ b/src/main/native/cpp/view/Logger.cpp
@@ -108,7 +108,9 @@ void Logger::Display() {
   sysid::CreateTooltip(
       "The logger assumes that the code will be sending recorded rotations "
       "over NetworkTables. This value will then be multiplied by the units per "
-      "rotation to get the measurement in the units you specified.");
+      "rotation to get the measurement in the units you specified.\n\nFor "
+      "non-rotational units (e.g. meters), this value is usually the wheel "
+      "diameter times pi.");
   // Create a section for voltage parameters.
   ImGui::Separator();
   ImGui::Spacing();

--- a/src/main/native/include/sysid/Util.h
+++ b/src/main/native/include/sysid/Util.h
@@ -13,6 +13,15 @@
 #define SYSID_PATH_SEPARATOR "/"
 #endif
 
+// The generated AppleScript by portable-file-dialogs for just *.json does not
+// work correctly because it is a uniform type identifier. This means that
+// "public." needs to be prepended to it.
+#ifdef __APPLE__
+#define SYSID_PFD_JSON_EXT "*.public.json"
+#else
+#define SYSID_PFD_JSON_EXT "*.json"
+#endif
+
 namespace sysid {
 void CreateTooltip(const char* text);
 std::vector<std::string> Split(const std::string& s, char c);

--- a/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -66,8 +66,8 @@ class AnalysisManager {
     int dataset = 0;
 
     /** The conversion factors. These contain values to convert feedback gains
-     * by gearing and epr. */
-    int epr = 1440;
+     * by gearing and cpr. */
+    int cpr = 1440;
     double gearing = 1;
     bool convertGainsToEncTicks = false;
   };

--- a/src/main/native/include/sysid/analysis/ArmSim.h
+++ b/src/main/native/include/sysid/analysis/ArmSim.h
@@ -1,0 +1,63 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <Eigen/Core>
+#include <units/time.h>
+#include <units/voltage.h>
+
+namespace sysid {
+
+class ArmSim {
+ public:
+  /**
+   * @param Ks              Static friction gain.
+   * @param Kv              Velocity gain.
+   * @param Ka              Acceleration gain.
+   * @param Kcos            Gravity cosine gain.
+   * @param initialPosition Initial elevator position.
+   * @param initialVelocity Initial elevator velocity.
+   */
+  ArmSim(double Ks, double Kv, double Ka, double Kcos,
+         double initialPosition = 0.0, double initialVelocity = 0.0);
+
+  /**
+   * Simulates affine state-space system dx/dt = Ax + Bu + c sgn(x) + d forward
+   * dt seconds.
+   *
+   * @param voltage Voltage to apply over the timestep.
+   * @param dt      Sammple period.
+   */
+  void Update(units::volt_t voltage, units::second_t dt);
+
+  /**
+   * Returns the position.
+   */
+  double GetPosition() const;
+
+  /**
+   * Returns the velocity.
+   */
+  double GetVelocity() const;
+
+  /**
+   * Returns the acceleration for the current state and given input.
+   */
+  double GetAcceleration(units::volt_t voltage) const;
+
+  /**
+   * Resets model position and velocity.
+   */
+  void Reset(double position = 0.0, double velocity = 0.0);
+
+ private:
+  Eigen::Matrix<double, 1, 1> m_A;
+  Eigen::Matrix<double, 1, 1> m_B;
+  Eigen::Matrix<double, 1, 1> m_c;
+  Eigen::Matrix<double, 1, 1> m_d;
+  Eigen::Matrix<double, 2, 1> m_x;
+};
+
+}  // namespace sysid

--- a/src/main/native/include/sysid/analysis/ElevatorSim.h
+++ b/src/main/native/include/sysid/analysis/ElevatorSim.h
@@ -1,0 +1,63 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <Eigen/Core>
+#include <units/time.h>
+#include <units/voltage.h>
+
+namespace sysid {
+
+class ElevatorSim {
+ public:
+  /**
+   * @param Ks              Static friction gain.
+   * @param Kv              Velocity gain.
+   * @param Ka              Acceleration gain.
+   * @param Kg              Gravity gain.
+   * @param initialPosition Initial elevator position.
+   * @param initialVelocity Initial elevator velocity.
+   */
+  ElevatorSim(double Ks, double Kv, double Ka, double Kg,
+              double initialPosition = 0.0, double initialVelocity = 0.0);
+
+  /**
+   * Simulates affine state-space system dx/dt = Ax + Bu + c sgn(x) + d forward
+   * dt seconds.
+   *
+   * @param voltage Voltage to apply over the timestep.
+   * @param dt      Sammple period.
+   */
+  void Update(units::volt_t voltage, units::second_t dt);
+
+  /**
+   * Returns the position.
+   */
+  double GetPosition() const;
+
+  /**
+   * Returns the velocity.
+   */
+  double GetVelocity() const;
+
+  /**
+   * Returns the acceleration for the current state and given input.
+   */
+  double GetAcceleration(units::volt_t voltage) const;
+
+  /**
+   * Resets model position and velocity.
+   */
+  void Reset(double position = 0.0, double velocity = 0.0);
+
+ private:
+  Eigen::Matrix<double, 2, 2> m_A;
+  Eigen::Matrix<double, 2, 1> m_B;
+  Eigen::Matrix<double, 2, 1> m_c;
+  Eigen::Matrix<double, 2, 1> m_d;
+  Eigen::Matrix<double, 2, 1> m_x;
+};
+
+}  // namespace sysid

--- a/src/main/native/include/sysid/analysis/SimpleMotorSim.h
+++ b/src/main/native/include/sysid/analysis/SimpleMotorSim.h
@@ -1,0 +1,61 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <Eigen/Core>
+#include <units/time.h>
+#include <units/voltage.h>
+
+namespace sysid {
+
+class SimpleMotorSim {
+ public:
+  /**
+   * @param Ks              Static friction gain.
+   * @param Kv              Velocity gain.
+   * @param Ka              Acceleration gain.
+   * @param initialPosition Initial elevator position.
+   * @param initialVelocity Initial elevator velocity.
+   */
+  SimpleMotorSim(double Ks, double Kv, double Ka, double initialPosition = 0.0,
+                 double initialVelocity = 0.0);
+
+  /**
+   * Simulates affine state-space system dx/dt = Ax + Bu + c sgn(x) forward dt
+   * seconds.
+   *
+   * @param voltage Voltage to apply over the timestep.
+   * @param dt      Sammple period.
+   */
+  void Update(units::volt_t voltage, units::second_t dt);
+
+  /**
+   * Returns the position.
+   */
+  double GetPosition() const;
+
+  /**
+   * Returns the velocity.
+   */
+  double GetVelocity() const;
+
+  /**
+   * Returns the acceleration for the current state and given input.
+   */
+  double GetAcceleration(units::volt_t voltage) const;
+
+  /**
+   * Resets model position and velocity.
+   */
+  void Reset(double position = 0.0, double velocity = 0.0);
+
+ private:
+  Eigen::Matrix<double, 2, 2> m_A;
+  Eigen::Matrix<double, 2, 1> m_B;
+  Eigen::Matrix<double, 2, 1> m_c;
+  Eigen::Matrix<double, 2, 1> m_x;
+};
+
+}  // namespace sysid

--- a/src/main/native/include/sysid/view/Analyzer.h
+++ b/src/main/native/include/sysid/view/Analyzer.h
@@ -11,7 +11,10 @@
 #include <vector>
 
 #include <glass/View.h>
+#include <implot.h>
 #include <portable-file-dialogs.h>
+#include <units/time.h>
+#include <units/voltage.h>
 #include <wpi/Logger.h>
 #include <wpi/StringMap.h>
 
@@ -51,6 +54,49 @@ class Analyzer : public glass::View {
     const char* xlabel;
     const char* ylabel;
   };
+
+  /**
+   * Plots time domain simulation of feedforward gains
+   */
+  template <typename Model>
+  void PlotTimeDomainSim(const PlotData& data, Model model) {
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 1.5);
+
+    std::vector<double> xs;
+    std::vector<double> ys;
+
+    // Get data list and initialize model state
+    auto preparedData = *(data.data());
+    xs.emplace_back(0.0);
+    ys.emplace_back(preparedData[0].velocity);
+
+    model.Reset(preparedData[0].position, preparedData[0].velocity);
+    units::second_t t = 0_s;
+    for (int j = 1; j < preparedData.size(); ++j) {
+      const auto& prev = preparedData[j - 1];
+      const auto& now = preparedData[j];
+
+      auto dt =
+          units::second_t{now.timestamp} - units::second_t{prev.timestamp};
+      t += dt;
+
+      // If there's a large gap or the time went backwards, it's a new
+      // section of data, so reset the model state
+      if (dt < 0_s || dt > 1_s) {
+        ImPlot::PlotLine("##Fit", &xs[0], &ys[0], xs.size());
+        xs.clear();
+        ys.clear();
+        model.Reset(now.position, now.velocity);
+        continue;
+      }
+
+      model.Update(units::volt_t{prev.voltage}, dt);
+
+      xs.emplace_back(t);
+      ys.emplace_back(model.GetVelocity());
+    }
+    ImPlot::PlotLine("##Fit", &xs[0], &ys[0], xs.size());
+  }
 
   bool first = true;
   std::string m_exception;

--- a/src/main/native/include/sysid/view/JSONConverter.h
+++ b/src/main/native/include/sysid/view/JSONConverter.h
@@ -23,6 +23,8 @@ class JSONConverter : public glass::View {
   std::string m_location;
   std::unique_ptr<pfd::open_file> m_opener;
 
+  std::string m_exception;
+
   double m_timestamp = 0;
 };
 }  // namespace sysid

--- a/src/main/native/include/sysid/view/Logger.h
+++ b/src/main/native/include/sysid/view/Logger.h
@@ -54,8 +54,6 @@ class Logger : public glass::View {
 
   std::string m_popupText;
 
-  int* m_team = nullptr;
-
   std::string m_opened;
   std::string m_exception;
 };

--- a/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
+++ b/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
@@ -2,11 +2,6 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <units/acceleration.h>
-#include <units/length.h>
-#include <units/velocity.h>
-#include <units/voltage.h>
-
 #include "gtest/gtest.h"
 #include "sysid/analysis/FeedbackAnalysis.h"
 #include "sysid/analysis/FeedbackControllerPreset.h"

--- a/src/test/native/cpp/analysis/FeedforwardAnalysisTest.cpp
+++ b/src/test/native/cpp/analysis/FeedforwardAnalysisTest.cpp
@@ -97,10 +97,10 @@ TEST(FeedforwardAnalysis, Arm1) {
                                              sysid::analysis::kArm);
   auto& gains = std::get<0>(ff);
 
-  EXPECT_NEAR(gains[0], Ks, 0.005);
-  EXPECT_NEAR(gains[1], Kv, 0.005);
-  EXPECT_NEAR(gains[2], Ka, 0.005);
-  EXPECT_NEAR(gains[3], Kcos, 0.005);
+  EXPECT_NEAR(gains[0], Ks, 0.003);
+  EXPECT_NEAR(gains[1], Kv, 0.003);
+  EXPECT_NEAR(gains[2], Ka, 0.003);
+  EXPECT_NEAR(gains[3], Kcos, 0.003);
 }
 
 TEST(FeedforwardAnalysis, Arm2) {
@@ -114,10 +114,10 @@ TEST(FeedforwardAnalysis, Arm2) {
                                              sysid::analysis::kArm);
   auto& gains = std::get<0>(ff);
 
-  EXPECT_NEAR(gains[0], Ks, 0.005);
-  EXPECT_NEAR(gains[1], Kv, 0.005);
-  EXPECT_NEAR(gains[2], Ka, 0.005);
-  EXPECT_NEAR(gains[3], Kcos, 0.005);
+  EXPECT_NEAR(gains[0], Ks, 0.003);
+  EXPECT_NEAR(gains[1], Kv, 0.003);
+  EXPECT_NEAR(gains[2], Ka, 0.003);
+  EXPECT_NEAR(gains[3], Kcos, 0.003);
 }
 
 TEST(FeedforwardAnalysis, Drivetrain1) {
@@ -130,9 +130,9 @@ TEST(FeedforwardAnalysis, Drivetrain1) {
                                              sysid::analysis::kDrivetrain);
   auto& gains = std::get<0>(ff);
 
-  EXPECT_NEAR(gains[0], Ks, 0.006);
-  EXPECT_NEAR(gains[1], Kv, 0.005);
-  EXPECT_NEAR(gains[2], Ka, 0.005);
+  EXPECT_NEAR(gains[0], Ks, 0.003);
+  EXPECT_NEAR(gains[1], Kv, 0.003);
+  EXPECT_NEAR(gains[2], Ka, 0.003);
 }
 
 TEST(FeedforwardAnalysis, Drivetrain2) {
@@ -145,9 +145,9 @@ TEST(FeedforwardAnalysis, Drivetrain2) {
                                              sysid::analysis::kDrivetrain);
   auto& gains = std::get<0>(ff);
 
-  EXPECT_NEAR(gains[0], Ks, 0.005);
-  EXPECT_NEAR(gains[1], Kv, 0.005);
-  EXPECT_NEAR(gains[2], Ka, 0.005);
+  EXPECT_NEAR(gains[0], Ks, 0.003);
+  EXPECT_NEAR(gains[1], Kv, 0.003);
+  EXPECT_NEAR(gains[2], Ka, 0.003);
 }
 
 TEST(FeedforwardAnalysis, Elevator1) {
@@ -161,10 +161,10 @@ TEST(FeedforwardAnalysis, Elevator1) {
                                              sysid::analysis::kElevator);
   auto& gains = std::get<0>(ff);
 
-  EXPECT_NEAR(gains[0], Ks, 0.005);
-  EXPECT_NEAR(gains[1], Kv, 0.005);
-  EXPECT_NEAR(gains[2], Ka, 0.005);
-  EXPECT_NEAR(gains[3], Kg, 0.005);
+  EXPECT_NEAR(gains[0], Ks, 0.003);
+  EXPECT_NEAR(gains[1], Kv, 0.003);
+  EXPECT_NEAR(gains[2], Ka, 0.003);
+  EXPECT_NEAR(gains[3], Kg, 0.003);
 }
 
 TEST(FeedforwardAnalysis, Elevator2) {
@@ -178,10 +178,10 @@ TEST(FeedforwardAnalysis, Elevator2) {
                                              sysid::analysis::kElevator);
   auto& gains = std::get<0>(ff);
 
-  EXPECT_NEAR(gains[0], Ks, 0.005);
-  EXPECT_NEAR(gains[1], Kv, 0.005);
-  EXPECT_NEAR(gains[2], Ka, 0.005);
-  EXPECT_NEAR(gains[3], Kg, 0.005);
+  EXPECT_NEAR(gains[0], Ks, 0.003);
+  EXPECT_NEAR(gains[1], Kv, 0.003);
+  EXPECT_NEAR(gains[2], Ka, 0.003);
+  EXPECT_NEAR(gains[3], Kg, 0.003);
 }
 
 TEST(FeedforwardAnalysis, Simple1) {
@@ -194,9 +194,9 @@ TEST(FeedforwardAnalysis, Simple1) {
                                              sysid::analysis::kSimple);
   auto& gains = std::get<0>(ff);
 
-  EXPECT_NEAR(gains[0], Ks, 0.006);
-  EXPECT_NEAR(gains[1], Kv, 0.005);
-  EXPECT_NEAR(gains[2], Ka, 0.005);
+  EXPECT_NEAR(gains[0], Ks, 0.003);
+  EXPECT_NEAR(gains[1], Kv, 0.003);
+  EXPECT_NEAR(gains[2], Ka, 0.003);
 }
 
 TEST(FeedforwardAnalysis, Simple2) {
@@ -209,7 +209,7 @@ TEST(FeedforwardAnalysis, Simple2) {
                                              sysid::analysis::kSimple);
   auto& gains = std::get<0>(ff);
 
-  EXPECT_NEAR(gains[0], Ks, 0.005);
-  EXPECT_NEAR(gains[1], Kv, 0.005);
-  EXPECT_NEAR(gains[2], Ka, 0.005);
+  EXPECT_NEAR(gains[0], Ks, 0.003);
+  EXPECT_NEAR(gains[1], Kv, 0.003);
+  EXPECT_NEAR(gains[2], Ka, 0.003);
 }

--- a/src/test/native/cpp/analysis/FeedforwardAnalysisTest.cpp
+++ b/src/test/native/cpp/analysis/FeedforwardAnalysisTest.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <cmath>
+
+#include <units/time.h>
+#include <units/voltage.h>
+
+#include "gtest/gtest.h"
+#include "sysid/analysis/AnalysisManager.h"
+#include "sysid/analysis/ArmSim.h"
+#include "sysid/analysis/ElevatorSim.h"
+#include "sysid/analysis/FeedforwardAnalysis.h"
+#include "sysid/analysis/SimpleMotorSim.h"
+
+/**
+ * Return simulated test data for a given simulation model.
+ *
+ * @param Ks   Static friction gain.
+ * @param Kv   Velocity gain.
+ * @param Ka   Acceleration gain.
+ * @param Kcos Gravity cosine gain.
+ */
+template <typename Model>
+sysid::Storage CollectData(Model& model) {
+  constexpr auto kUstep = 0.25_V / 1_s;
+  constexpr units::volt_t kUmax = 7_V;
+  constexpr units::second_t T = 5_ms;
+  constexpr units::second_t kTestDuration = 5_s;
+
+  sysid::Storage storage;
+  auto& [slow, fast] = storage;
+
+  // Slow forward test
+  auto voltage = 0_V;
+  for (int i = 0; i < (kTestDuration / T).to<double>(); ++i) {
+    slow.emplace_back(sysid::PreparedData{
+        (i * T).to<double>(), voltage.to<double>(), model.GetPosition(),
+        model.GetVelocity(), model.GetAcceleration(voltage),
+        std::cos(model.GetPosition())});
+
+    model.Update(voltage, T);
+    voltage += kUstep * T;
+  }
+
+  // Slow backward test
+  model.Reset();
+  voltage = 0_V;
+  for (int i = 0; i < (kTestDuration / T).to<double>(); ++i) {
+    slow.emplace_back(sysid::PreparedData{
+        (i * T).to<double>(), voltage.to<double>(), model.GetPosition(),
+        model.GetVelocity(), model.GetAcceleration(voltage),
+        std::cos(model.GetPosition())});
+
+    model.Update(voltage, T);
+    voltage -= kUstep * T;
+  }
+
+  // Fast forward test
+  model.Reset();
+  voltage = 0_V;
+  for (int i = 0; i < (kTestDuration / T).to<double>(); ++i) {
+    fast.emplace_back(sysid::PreparedData{
+        (i * T).to<double>(), voltage.to<double>(), model.GetPosition(),
+        model.GetVelocity(), model.GetAcceleration(voltage),
+        std::cos(model.GetPosition())});
+
+    model.Update(voltage, T);
+    voltage = kUmax;
+  }
+
+  // Fast backward test
+  model.Reset();
+  voltage = 0_V;
+  for (int i = 0; i < (kTestDuration / T).to<double>(); ++i) {
+    fast.emplace_back(sysid::PreparedData{
+        (i * T).to<double>(), voltage.to<double>(), model.GetPosition(),
+        model.GetVelocity(), model.GetAcceleration(voltage),
+        std::cos(model.GetPosition())});
+
+    model.Update(voltage, T);
+    voltage = -kUmax;
+  }
+
+  return storage;
+}
+
+TEST(FeedforwardAnalysis, Arm1) {
+  constexpr double Ks = 1.01;
+  constexpr double Kv = 3.060;
+  constexpr double Ka = 0.327;
+  constexpr double Kcos = -0.211;
+
+  sysid::ArmSim model{Ks, Kv, Ka, Kcos};
+  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
+                                             sysid::analysis::kArm);
+  auto& gains = std::get<0>(ff);
+
+  EXPECT_NEAR(gains[0], Ks, 0.005);
+  EXPECT_NEAR(gains[1], Kv, 0.005);
+  EXPECT_NEAR(gains[2], Ka, 0.005);
+  EXPECT_NEAR(gains[3], Kcos, 0.005);
+}
+
+TEST(FeedforwardAnalysis, Arm2) {
+  constexpr double Ks = 0.547;
+  constexpr double Kv = 0.0693;
+  constexpr double Ka = 0.1170;
+  constexpr double Kcos = -0.122;
+
+  sysid::ArmSim model{Ks, Kv, Ka, Kcos};
+  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
+                                             sysid::analysis::kArm);
+  auto& gains = std::get<0>(ff);
+
+  EXPECT_NEAR(gains[0], Ks, 0.005);
+  EXPECT_NEAR(gains[1], Kv, 0.005);
+  EXPECT_NEAR(gains[2], Ka, 0.005);
+  EXPECT_NEAR(gains[3], Kcos, 0.005);
+}
+
+TEST(FeedforwardAnalysis, Drivetrain1) {
+  constexpr double Ks = 1.01;
+  constexpr double Kv = 3.060;
+  constexpr double Ka = 0.327;
+
+  sysid::SimpleMotorSim model{Ks, Kv, Ka};
+  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
+                                             sysid::analysis::kDrivetrain);
+  auto& gains = std::get<0>(ff);
+
+  EXPECT_NEAR(gains[0], Ks, 0.006);
+  EXPECT_NEAR(gains[1], Kv, 0.005);
+  EXPECT_NEAR(gains[2], Ka, 0.005);
+}
+
+TEST(FeedforwardAnalysis, Drivetrain2) {
+  constexpr double Ks = 0.547;
+  constexpr double Kv = 0.0693;
+  constexpr double Ka = 0.1170;
+
+  sysid::SimpleMotorSim model{Ks, Kv, Ka};
+  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
+                                             sysid::analysis::kDrivetrain);
+  auto& gains = std::get<0>(ff);
+
+  EXPECT_NEAR(gains[0], Ks, 0.005);
+  EXPECT_NEAR(gains[1], Kv, 0.005);
+  EXPECT_NEAR(gains[2], Ka, 0.005);
+}
+
+TEST(FeedforwardAnalysis, Elevator1) {
+  constexpr double Ks = 1.01;
+  constexpr double Kv = 3.060;
+  constexpr double Ka = 0.327;
+  constexpr double Kg = -0.211;
+
+  sysid::ElevatorSim model{Ks, Kv, Ka, Kg};
+  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
+                                             sysid::analysis::kElevator);
+  auto& gains = std::get<0>(ff);
+
+  EXPECT_NEAR(gains[0], Ks, 0.005);
+  EXPECT_NEAR(gains[1], Kv, 0.005);
+  EXPECT_NEAR(gains[2], Ka, 0.005);
+  EXPECT_NEAR(gains[3], Kg, 0.005);
+}
+
+TEST(FeedforwardAnalysis, Elevator2) {
+  constexpr double Ks = 0.547;
+  constexpr double Kv = 0.0693;
+  constexpr double Ka = 0.1170;
+  constexpr double Kg = -0.122;
+
+  sysid::ElevatorSim model{Ks, Kv, Ka, Kg};
+  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
+                                             sysid::analysis::kElevator);
+  auto& gains = std::get<0>(ff);
+
+  EXPECT_NEAR(gains[0], Ks, 0.005);
+  EXPECT_NEAR(gains[1], Kv, 0.005);
+  EXPECT_NEAR(gains[2], Ka, 0.005);
+  EXPECT_NEAR(gains[3], Kg, 0.005);
+}
+
+TEST(FeedforwardAnalysis, Simple1) {
+  constexpr double Ks = 1.01;
+  constexpr double Kv = 3.060;
+  constexpr double Ka = 0.327;
+
+  sysid::SimpleMotorSim model{Ks, Kv, Ka};
+  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
+                                             sysid::analysis::kSimple);
+  auto& gains = std::get<0>(ff);
+
+  EXPECT_NEAR(gains[0], Ks, 0.006);
+  EXPECT_NEAR(gains[1], Kv, 0.005);
+  EXPECT_NEAR(gains[2], Ka, 0.005);
+}
+
+TEST(FeedforwardAnalysis, Simple2) {
+  constexpr double Ks = 0.547;
+  constexpr double Kv = 0.0693;
+  constexpr double Ka = 0.1170;
+
+  sysid::SimpleMotorSim model{Ks, Kv, Ka};
+  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
+                                             sysid::analysis::kSimple);
+  auto& gains = std::get<0>(ff);
+
+  EXPECT_NEAR(gains[0], Ks, 0.005);
+  EXPECT_NEAR(gains[1], Kv, 0.005);
+  EXPECT_NEAR(gains[2], Ka, 0.005);
+}


### PR DESCRIPTION
Looks like the key is just cleaning up the data before OLS. I need to figure out where those two outlier points in the dynamic acceleration graph are coming from.
![Screenshot_2021-03-08_01-15-30](https://user-images.githubusercontent.com/2748555/110300583-e13df000-7fab-11eb-9cee-3f81c091d05d.png)
![Screenshot_2021-03-08_01-17-42](https://user-images.githubusercontent.com/2748555/110300746-1a766000-7fac-11eb-9a89-bf7c1a2c6780.png)

I noticed the dt varies from 4-6ms, so tighter timing might help here.